### PR TITLE
Add Copilot/AI Resources section to Developer-Resources.md

### DIFF
--- a/Docs/Developer-Resources.md
+++ b/Docs/Developer-Resources.md
@@ -24,3 +24,6 @@
 - [Development Principles to follow](https://deviq.com/category/principles/)
 - [Design Patterns](https://deviq.com/category/patterns/) ways to structure you code to solve various problems.
 - [Anti Patterns](https://deviq.com/category/antipatterns/) ways to make your code horrible.
+
+## Copilot/AI Resources
+- [GitHub Copilot](https://github.com/features/copilot/tutorials)


### PR DESCRIPTION
This pull request adds a new section to the developer resources documentation, providing a link to GitHub Copilot tutorials for AI-assisted development.

Documentation update:

* Added a "Copilot/AI Resources" section to `Docs/Developer-Resources.md`, including a link to GitHub Copilot tutorials.